### PR TITLE
Goroutine cannot be stopped with Kill() when using TCP

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -23,6 +23,7 @@ func (s *ServerSuite) TestTailFile(c *C) {
 	server.SetFormat(RFC3164)
 	server.SetHandler(handler)
 	server.ListenUDP("0.0.0.0:5141")
+	server.ListenTCP("0.0.0.0:5141")
 
 	go func(server *Server) {
 		time.Sleep(100 * time.Microsecond)


### PR DESCRIPTION
When `Kill()` is called the goroutine in `goAcceptConnection()` goes into an infinite loop and `Wait()` blocks forever.  When `Kill()` closes all the connections `Accept()` returns with an error.  This change allows to send a signal to exit the goroutine that is doing the `Accept()` so `Wait()` can proceed.  The channel is closed (rather than sending data) to broadcast the signal in case multiple goroutines exist in the `Accept()` state.
