### PR TITLE
Add support for TCP connection timeout and to terminate on Kill()

### DIFF
--- a/server.go
+++ b/server.go
@@ -27,7 +27,7 @@ type Server struct {
 	format                  Format
 	handler                 Handler
 	lastError               error
-	ReadTimeoutMilliseconds int64
+	readTimeoutMilliseconds int64
 }
 
 //NewServer returns a new Server
@@ -45,6 +45,11 @@ func (self *Server) SetFormat(format Format) {
 //Sets the handler, this handler with receive every syslog entry
 func (self *Server) SetHandler(handler Handler) {
 	self.handler = handler
+}
+
+//Sets the connection timeout for TCP connections, in milliseconds
+func (self *Server) SetTimeout(millseconds int64) {
+	self.readTimeoutMilliseconds = millseconds
 }
 
 //Configure the server for listen on an UDP addr
@@ -176,8 +181,8 @@ func (self *Server) scan(scanCloser *ScanCloser) {
 				break loop
 			default:
 			}
-			if self.ReadTimeoutMilliseconds > 0 {
-				scanCloser.closer.SetReadDeadline(time.Now().Add(time.Duration(self.ReadTimeoutMilliseconds) * time.Millisecond))
+			if self.readTimeoutMilliseconds > 0 {
+				scanCloser.closer.SetReadDeadline(time.Now().Add(time.Duration(self.readTimeoutMilliseconds) * time.Millisecond))
 			}
 			if scanCloser.Scan() {
 				self.parser([]byte(scanCloser.Text()))

--- a/server_test.go
+++ b/server_test.go
@@ -120,7 +120,7 @@ func (s *ServerSuite) TestTcpTimeout(c *C) {
 	server := NewServer()
 	server.SetFormat(RFC3164)
 	server.SetHandler(handler)
-	server.ReadTimeoutMilliseconds = 10
+	server.SetTimeout(10)
 	con := ConnMock{ReadData: []byte(exampleSyslog), ReturnTimeout: true}
 	c.Check(con.isReadDeadline, Equals, false)
 	server.goScanConnection(&con, true)


### PR DESCRIPTION
When a client maintains a TCP connection open, the server is not able to terminate since it waits for the client to disconnect.  This adds support for a timeout on idle connections.  Also support was added to terminate right after a successful read if `Kill()` is called.

I initially setup `rsyslog` to relay logs to this server using TCP.  `rsyslog` maintains a connection open for a long time so this server was never able to exit.  A good timeout setting is about 15 seconds.
