### PR TITLE
Simplify Server (a little) by extracting a Format interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,3 @@ License
 -------
 
 MIT, see [LICENSE](LICENSE)
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/mcuadros/go-syslog/trend.png)](https://bitdeli.com/free "Bitdeli Badge")

--- a/format.go
+++ b/format.go
@@ -1,0 +1,27 @@
+package syslog
+
+import (
+	"github.com/jeromer/syslogparser"
+	"github.com/jeromer/syslogparser/rfc3164"
+	"github.com/jeromer/syslogparser/rfc5424"
+)
+
+type Format interface {
+	GetParser([]byte) syslogparser.LogParser
+}
+
+type format3164 struct {}
+type format5424 struct {}
+
+var (
+	RFC3164 = &format3164{}
+	RFC5424 = &format5424{}
+)
+
+func (fmt *format3164) GetParser (line []byte) syslogparser.LogParser {
+	return rfc3164.NewParser(line)
+}
+
+func (fmt *format5424) GetParser (line []byte) syslogparser.LogParser {
+	return rfc5424.NewParser(line)
+}

--- a/handler.go
+++ b/handler.go
@@ -6,7 +6,7 @@ import (
 
 //The handler receive every syslog entry at Handle method
 type Handler interface {
-	Handle(syslogparser.LogParts)
+	Handle(syslogparser.LogParts, int64, error)
 }
 
 type LogPartsChannel chan syslogparser.LogParts
@@ -30,6 +30,6 @@ func (self *ChannelHandler) SetChannel(channel LogPartsChannel) {
 }
 
 //Syslog entry receiver
-func (self *ChannelHandler) Handle(logParts syslogparser.LogParts) {
+func (self *ChannelHandler) Handle(logParts syslogparser.LogParts, messageLength int64, err error) {
 	self.channel <- logParts
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -14,7 +14,7 @@ func (s *HandlerSuite) TestHandle(c *C) {
 
 	channel := make(LogPartsChannel, 1)
 	handler := NewChannelHandler(channel)
-	handler.Handle(logPart)
+	handler.Handle(logPart, 10, nil)
 
 	fromChan := <-channel
 	c.Check(fromChan["tag"], Equals, logPart["tag"])

--- a/server.go
+++ b/server.go
@@ -206,11 +206,12 @@ func (self *Server) parser(line []byte) {
 		parser = self.getParserRFC5424(line)
 	}
 
-	if err := parser.Parse(); err != nil {
+	err := parser.Parse()
+	if err != nil {
 		self.lastError = err
 	}
 
-	go self.handler.Handle(parser.Dump())
+	go self.handler.Handle(parser.Dump(), int64(len(line)), err)
 }
 
 func (self *Server) getParserRFC3164(line []byte) *rfc3164.Parser {

--- a/server_test.go
+++ b/server_test.go
@@ -43,14 +43,20 @@ func (s *ServerSuite) TestTailFile(c *C) {
 	c.Check(handler.LastLogParts["hostname"], Equals, "hostname")
 	c.Check(handler.LastLogParts["tag"], Equals, "tag")
 	c.Check(handler.LastLogParts["content"], Equals, "content")
+	c.Check(handler.LastMessageLength, Equals, int64(len(exampleSyslog)))
+	c.Check(handler.LastError, IsNil)
 }
 
 type HandlerMock struct {
 	LastLogParts syslogparser.LogParts
+	LastMessageLength int64
+	LastError error
 }
 
 func (self *HandlerMock) Handle(logParts syslogparser.LogParts, msgLen int64, err error) {
 	self.LastLogParts = logParts
+	self.LastMessageLength = msgLen
+	self.LastError = err
 }
 
 type ConnMock struct {
@@ -127,4 +133,6 @@ func (s *ServerSuite) TestTcpTimeout(c *C) {
 	server.Wait()
 	c.Check(con.isReadDeadline, Equals, true)
 	c.Check(handler.LastLogParts, IsNil)
+	c.Check(handler.LastMessageLength, Equals, int64(0))
+	c.Check(handler.LastError, IsNil)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -49,7 +49,7 @@ type HandlerMock struct {
 	LastLogParts syslogparser.LogParts
 }
 
-func (self *HandlerMock) Handle(logParts syslogparser.LogParts) {
+func (self *HandlerMock) Handle(logParts syslogparser.LogParts, msgLen int64, err error) {
 	self.LastLogParts = logParts
 }
 


### PR DESCRIPTION
Replaces the `Format` enum (and corresponding `case` statement) with a `Format`
interface (consisting solely of the `GetParser()` method).