### PR TITLE
Fix for server.Kill() on UDP connections

### DIFF
--- a/server.go
+++ b/server.go
@@ -217,8 +217,9 @@ func (s *Server) Kill() error {
 		}
 	}
 	// Only need to close channel once to broadcast to all waiting
-	close(s.doneTcp)
-
+	if s.doneTcp != nil {
+		close(s.doneTcp)
+	}
 	return nil
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -121,6 +121,20 @@ func (s *ServerSuite) TestConnectionClose(c *C) {
 	}
 }
 
+func (s *ServerSuite) TestConnectionUDPKill(c *C) {
+	for _, closeConnection := range []bool{true, false} {
+		handler := new(HandlerMock)
+		server := NewServer()
+		server.SetFormat(RFC5424)
+		server.SetHandler(handler)
+		con := ConnMock{ReadData: []byte(exampleSyslog)}
+		server.goScanConnection(&con, closeConnection)
+		server.Kill()
+		server.Wait()
+		c.Check(con.isClosed, Equals, closeConnection)
+	}
+}
+
 func (s *ServerSuite) TestTcpTimeout(c *C) {
 	handler := new(HandlerMock)
 	server := NewServer()


### PR DESCRIPTION
Same as pull request https://github.com/mcuadros/go-syslog/pull/7 but with unittest and compatible to latest version.