### PR TITLE
Fix data race by waiting for Handler using server's WaitGroup

### DIFF
--- a/server.go
+++ b/server.go
@@ -202,7 +202,7 @@ func (s *Server) parser(line []byte, client string) {
 	logParts := parser.Dump()
 	logParts["client"] = client
 
-	go s.handler.Handle(logParts, int64(len(line)), err)
+	s.handler.Handle(logParts, int64(len(line)), err)
 }
 
 //Returns the last error


### PR DESCRIPTION
Handlers can take some time to run, and it's expected that after Server.Wait() returns the handler has already finished executing.

The following data race was triggered by tests and fixed by this pull request:

```
$ go test -race
==================
WARNING: DATA RACE
Read by goroutine 20:
  gopkg.in/mcuadros/go-syslog%2ev2.(*ServerSuite).TestTailFile()
      /Users/cezar.sa/go/src/gopkg.in/mcuadros/go-syslog.v2/server_test.go:43 +0x283
  runtime.call16()
      /usr/local/Cellar/go/1.4.2/libexec/src/runtime/asm_amd64.s:401 +0x44
  reflect.Value.Call()
      /usr/local/Cellar/go/1.4.2/libexec/src/reflect/value.go:296 +0xd8
  launchpad.net/gocheck.func·006()
      /Users/cezar.sa/go/src/launchpad.net/gocheck/gocheck.go:733 +0x51d
  launchpad.net/gocheck.func·004()
      /Users/cezar.sa/go/src/launchpad.net/gocheck/gocheck.go:628 +0xf7

Previous write by goroutine 24:
  gopkg.in/mcuadros/go-syslog%2ev2.(*HandlerMock).Handle()
      /Users/cezar.sa/go/src/gopkg.in/mcuadros/go-syslog.v2/server_test.go:85 +0x36

Goroutine 20 (running) created at:
  launchpad.net/gocheck.(*suiteRunner).forkCall()
      /Users/cezar.sa/go/src/launchpad.net/gocheck/gocheck.go:629 +0x544
  launchpad.net/gocheck.(*suiteRunner).forkTest()
      /Users/cezar.sa/go/src/launchpad.net/gocheck/gocheck.go:765 +0xf2
  launchpad.net/gocheck.(*suiteRunner).runTest()
      /Users/cezar.sa/go/src/launchpad.net/gocheck/gocheck.go:770 +0x3f
  launchpad.net/gocheck.(*suiteRunner).run()
      /Users/cezar.sa/go/src/launchpad.net/gocheck/gocheck.go:584 +0x3aa
  launchpad.net/gocheck.Run()
      /Users/cezar.sa/go/src/launchpad.net/gocheck/run.go:76 +0x57
  launchpad.net/gocheck.RunAll()
      /Users/cezar.sa/go/src/launchpad.net/gocheck/run.go:68 +0x132
  launchpad.net/gocheck.TestingT()
      /Users/cezar.sa/go/src/launchpad.net/gocheck/run.go:56 +0x582
  gopkg.in/mcuadros/go-syslog%2ev2.Test()
      /Users/cezar.sa/go/src/gopkg.in/mcuadros/go-syslog.v2/server_test.go:13 +0x35
  testing.tRunner()
      /usr/local/Cellar/go/1.4.2/libexec/src/testing/testing.go:447 +0x133

Goroutine 24 (finished) created at:
  gopkg.in/mcuadros/go-syslog%2ev2.(*Server).parser()
      /Users/cezar.sa/go/src/gopkg.in/mcuadros/go-syslog.v2/server.go:196 +0x1bb
  gopkg.in/mcuadros/go-syslog%2ev2.(*Server).scan()
      /Users/cezar.sa/go/src/gopkg.in/mcuadros/go-syslog.v2/server.go:163 +0x146
==================
```