### PR TITLE
Fix RFC6587 parsing on UDP.

### DIFF
--- a/server.go
+++ b/server.go
@@ -299,7 +299,13 @@ func (s *Server) goParseDatagrams() {
 				if !ok {
 					return
 				}
-				s.parser(msg.message, msg.client)
+				if sf := s.format.GetSplitFunc(); sf != nil {
+					if _, token, err := sf(msg.message, true); err == nil {
+						s.parser(token, msg.client)
+					}
+				} else {
+					s.parser(msg.message, msg.client)
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
My earlier fixes to UDP packet parsing broke RFC6587 parsing. By eliminating use of the scanner (and thus the requirement that lines should end with a `\n` character) I also removed the more functional RFC6587 scanner which does not require a `\n` but does advance over the length field. This patch restores use of the scanner where it is explicitly specified (currently just RFC6587).

Signed-off-by: Alex Bligh <alex@alex.org.uk>