### PR TITLE
Record tls peer in logParts struct

### DIFF
--- a/servertls_test.go
+++ b/servertls_test.go
@@ -81,6 +81,7 @@ func (s *ServerSuite) TestTLS(c *C) {
 	c.Check(handler.LastLogParts["hostname"], Equals, "hostname")
 	c.Check(handler.LastLogParts["tag"], Equals, "tag")
 	c.Check(handler.LastLogParts["content"], Equals, "content")
+	c.Check(handler.LastLogParts["tls_peer"], Equals, "dummycert1")
 	c.Check(handler.LastMessageLength, Equals, int64(len(exampleSyslog)))
 	c.Check(handler.LastError, IsNil)
 }


### PR DESCRIPTION
* Record the TLS peer name in the `logParts` structure.

* By default use the CN of the first peer certificate.

* Allow a function to be specified which can extract whatever
  data is required from the connection and optionally return
  `ok=false` in order to close the connection.

* Add a test for the above

Signed-off-by: Alex Bligh <alex@alex.org.uk>