### PR TITLE
Improve SSL testing

### DIFF
--- a/servertls_test.go
+++ b/servertls_test.go
@@ -26,7 +26,6 @@ func getServerConfig() *tls.Config {
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{cert},
 		ClientCAs:    capool,
-		ServerName:   "dummycert1",
 	}
 	config.Rand = rand.Reader
 
@@ -46,7 +45,7 @@ func getClientConfig() *tls.Config {
 
 	config := tls.Config{
 		Certificates:       []tls.Certificate{cert},
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: false,
 		ServerName:         "dummycert1",
 		RootCAs:            capool,
 	}


### PR DESCRIPTION
Remove unnecessary skipping of SSL validation
Remove unnecessary setup of ServerName for server side (CN is in the cert)

Signed-off-by: Alex Bligh <alex@alex.org.uk>