### PR TITLE
Allow extensibility by not exposing types declared in internal pkgs

### DIFF
--- a/format/automatic.go
+++ b/format/automatic.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"strconv"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser"
 	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc3164"
 	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc5424"
 )
@@ -57,12 +56,12 @@ func detect(data []byte) (detected int, err error) {
 	return detectedUnknown, nil
 }
 
-func (f *Automatic) GetParser(line []byte) syslogparser.LogParser {
+func (f *Automatic) GetParser(line []byte) LogParser {
 	switch format, _ := detect(line); format {
 	case detectedRFC3164:
-		return rfc3164.NewParser(line)
+		return &parserWrapper{rfc3164.NewParser(line)}
 	case detectedRFC5424:
-		return rfc5424.NewParser(line)
+		return &parserWrapper{rfc5424.NewParser(line)}
 	default:
 		// If the line was an RFC6587 line, the splitter should already have removed the length,
 		// so one of the above two will be chosen if the line is correctly formed. However, it
@@ -70,7 +69,7 @@ func (f *Automatic) GetParser(line []byte) syslogparser.LogParser {
 		// will return detectedRFC6587. The line may also simply be malformed after the length in
 		// which case we will have detectedUnknown. In this case we return the simplest parser so
 		// the illegally formatted line is properly handled
-		return rfc3164.NewParser(line)
+		return &parserWrapper{rfc3164.NewParser(line)}
 	}
 }
 

--- a/format/format.go
+++ b/format/format.go
@@ -2,11 +2,28 @@ package format
 
 import (
 	"bufio"
+	"time"
 
 	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser"
 )
 
+type LogParts map[string]interface{}
+
+type LogParser interface {
+	Parse() error
+	Dump() LogParts
+	Location(*time.Location)
+}
+
 type Format interface {
-	GetParser([]byte) syslogparser.LogParser
+	GetParser([]byte) LogParser
 	GetSplitFunc() bufio.SplitFunc
+}
+
+type parserWrapper struct {
+	syslogparser.LogParser
+}
+
+func (w *parserWrapper) Dump() LogParts {
+	return LogParts(w.LogParser.Dump())
 }

--- a/format/rfc3164.go
+++ b/format/rfc3164.go
@@ -3,14 +3,13 @@ package format
 import (
 	"bufio"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser"
 	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc3164"
 )
 
 type RFC3164 struct{}
 
-func (f *RFC3164) GetParser(line []byte) syslogparser.LogParser {
-	return rfc3164.NewParser(line)
+func (f *RFC3164) GetParser(line []byte) LogParser {
+	return &parserWrapper{rfc3164.NewParser(line)}
 }
 
 func (f *RFC3164) GetSplitFunc() bufio.SplitFunc {

--- a/format/rfc5424.go
+++ b/format/rfc5424.go
@@ -3,14 +3,13 @@ package format
 import (
 	"bufio"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser"
 	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc5424"
 )
 
 type RFC5424 struct{}
 
-func (f *RFC5424) GetParser(line []byte) syslogparser.LogParser {
-	return rfc5424.NewParser(line)
+func (f *RFC5424) GetParser(line []byte) LogParser {
+	return &parserWrapper{rfc5424.NewParser(line)}
 }
 
 func (f *RFC5424) GetSplitFunc() bufio.SplitFunc {

--- a/format/rfc6587.go
+++ b/format/rfc6587.go
@@ -5,14 +5,13 @@ import (
 	"bytes"
 	"strconv"
 
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser"
 	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc5424"
 )
 
 type RFC6587 struct{}
 
-func (f *RFC6587) GetParser(line []byte) syslogparser.LogParser {
-	return rfc5424.NewParser(line)
+func (f *RFC6587) GetParser(line []byte) LogParser {
+	return &parserWrapper{rfc5424.NewParser(line)}
 }
 
 func (f *RFC6587) GetSplitFunc() bufio.SplitFunc {

--- a/handler.go
+++ b/handler.go
@@ -1,17 +1,15 @@
 package syslog
 
 import (
-	"gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser"
+	"gopkg.in/mcuadros/go-syslog.v2/format"
 )
-
-type LogParts syslogparser.LogParts
 
 //The handler receive every syslog entry at Handle method
 type Handler interface {
-	Handle(LogParts, int64, error)
+	Handle(format.LogParts, int64, error)
 }
 
-type LogPartsChannel chan LogParts
+type LogPartsChannel chan format.LogParts
 
 //The ChannelHandler will send all the syslog entries into the given channel
 type ChannelHandler struct {
@@ -32,6 +30,6 @@ func (h *ChannelHandler) SetChannel(channel LogPartsChannel) {
 }
 
 //Syslog entry receiver
-func (h *ChannelHandler) Handle(logParts LogParts, messageLength int64, err error) {
+func (h *ChannelHandler) Handle(logParts format.LogParts, messageLength int64, err error) {
 	h.channel <- logParts
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -2,6 +2,7 @@ package syslog
 
 import (
 	. "gopkg.in/check.v1"
+	"gopkg.in/mcuadros/go-syslog.v2/format"
 )
 
 type HandlerSuite struct{}
@@ -9,7 +10,7 @@ type HandlerSuite struct{}
 var _ = Suite(&HandlerSuite{})
 
 func (s *HandlerSuite) TestHandle(c *C) {
-	logPart := LogParts{"tag": "foo"}
+	logPart := format.LogParts{"tag": "foo"}
 
 	channel := make(LogPartsChannel, 1)
 	handler := NewChannelHandler(channel)

--- a/server.go
+++ b/server.go
@@ -262,7 +262,7 @@ func (s *Server) parser(line []byte, client string, tlsPeer string) {
 	}
 	logParts["tls_peer"] = tlsPeer
 
-	s.handler.Handle(LogParts(logParts), int64(len(line)), err)
+	s.handler.Handle(logParts, int64(len(line)), err)
 }
 
 //Returns the last error

--- a/server_test.go
+++ b/server_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/mcuadros/go-syslog.v2/format"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -50,12 +51,12 @@ func (s *ServerSuite) TestTailFile(c *C) {
 }
 
 type HandlerMock struct {
-	LastLogParts      LogParts
+	LastLogParts      format.LogParts
 	LastMessageLength int64
 	LastError         error
 }
 
-func (s *HandlerMock) Handle(logParts LogParts, msgLen int64, err error) {
+func (s *HandlerMock) Handle(logParts format.LogParts, msgLen int64, err error) {
 	s.LastLogParts = logParts
 	s.LastMessageLength = msgLen
 	s.LastError = err


### PR DESCRIPTION
All exposed interfaces are now declared inside the go-syslog/format
package. This makes it possible to easily write a custom Format and
LogParser.

Fixes #30