### PR TITLE
Support non-transparent-framing

### DIFF
--- a/format/rfc6587.go
+++ b/format/rfc6587.go
@@ -27,11 +27,15 @@ func rfc6587ScannerSplit(data []byte, atEOF bool) (advance int, token []byte, er
 		pLength := data[0:i]
 		length, err := strconv.Atoi(string(pLength))
 		if err != nil {
+			if string(data[0:1]) == "<" {
+				// Assume this frame uses non-transparent-framing
+				return len(data), data, nil
+			}
 			return 0, nil, err
 		}
 		end := length + i + 1
 		if len(data) >= end {
-			//Return the frame with the length removed
+			// Return the frame with the length removed
 			return end, data[i+1 : end], nil
 		}
 	}

--- a/format/rfc6587_test.go
+++ b/format/rfc6587_test.go
@@ -45,6 +45,30 @@ func (s *FormatSuite) TestRFC6587_GetSplitFuncMultiSplit(c *C) {
 	c.Assert(i, Equals, len(find))
 }
 
+func (s *FormatSuite) TestRFC6587_GetSplitFuncMultiSplitNonTransparentFraming(c *C) {
+	f := RFC6587{}
+
+	find := []string{
+		"<1> I am a test.",
+		"<2> I am a test 2.",
+		"<3> hahahah",
+	}
+	buf := new(bytes.Buffer)
+	for _, i := range find {
+		fmt.Fprintf(buf, "%s", i)
+	}
+	scanner := bufio.NewScanner(buf)
+	scanner.Split(f.GetSplitFunc())
+
+	i := 0
+	for scanner.Scan() {
+		c.Assert(scanner.Text(), Equals, strings.Join(find, ""))
+		i++
+	}
+
+	c.Assert(i, Equals, 1)
+}
+
 func (s *FormatSuite) TestRFC6587_GetSplitBadSplit(c *C) {
 	f := RFC6587{}
 


### PR DESCRIPTION
[Section 3.4.2 of RFC6587](https://tools.ietf.org/html/rfc6587#section-3.4.2) defines _non-transparent-framing_. This patch changes `rfc6587.go` to assume it just encountered _non-transparent-framing_ if parsing an integer during _octet counting_ fails.

As the _trailer_ used in _non-transparent-framing_ is not exactly specified in the RFC, this patch does not try to find any and instead assumes that the whole remainder of scannable data belongs to just a single message.

Looking forward to suggestions on how to improve this, if you have any.