### PR TITLE
Don't try to parse hostname for RFC3164 over unix socket.

### DIFF
--- a/format/automatic.go
+++ b/format/automatic.go
@@ -56,10 +56,10 @@ func detect(data []byte) (detected int, err error) {
 	return detectedUnknown, nil
 }
 
-func (f *Automatic) GetParser(line []byte) LogParser {
+func (f *Automatic) getAnyParser(line []byte, isUnixSocket bool) LogParser {
 	switch format, _ := detect(line); format {
 	case detectedRFC3164:
-		return &parserWrapper{rfc3164.NewParser(line)}
+		return &parserWrapper{rfc3164.NewParser(line, isUnixSocket)}
 	case detectedRFC5424:
 		return &parserWrapper{rfc5424.NewParser(line)}
 	default:
@@ -69,8 +69,16 @@ func (f *Automatic) GetParser(line []byte) LogParser {
 		// will return detectedRFC6587. The line may also simply be malformed after the length in
 		// which case we will have detectedUnknown. In this case we return the simplest parser so
 		// the illegally formatted line is properly handled
-		return &parserWrapper{rfc3164.NewParser(line)}
+		return &parserWrapper{rfc3164.NewParser(line, isUnixSocket)}
 	}
+}
+
+func (f *Automatic) GetParser(line []byte) LogParser {
+	return f.getAnyParser(line, false)
+}
+
+func (f *Automatic) GetParserUnixSocket(line []byte) LogParser {
+	return f.getAnyParser(line, true)
 }
 
 func (f *Automatic) GetSplitFunc() bufio.SplitFunc {

--- a/format/format.go
+++ b/format/format.go
@@ -17,6 +17,7 @@ type LogParser interface {
 
 type Format interface {
 	GetParser([]byte) LogParser
+	GetParserUnixSocket([]byte) LogParser
 	GetSplitFunc() bufio.SplitFunc
 }
 

--- a/format/rfc3164.go
+++ b/format/rfc3164.go
@@ -9,7 +9,11 @@ import (
 type RFC3164 struct{}
 
 func (f *RFC3164) GetParser(line []byte) LogParser {
-	return &parserWrapper{rfc3164.NewParser(line)}
+	return &parserWrapper{rfc3164.NewParser(line, false)}
+}
+
+func (f *RFC3164) GetParserUnixSocket(line []byte) LogParser {
+	return &parserWrapper{rfc3164.NewParser(line, true)}
 }
 
 func (f *RFC3164) GetSplitFunc() bufio.SplitFunc {

--- a/format/rfc5424.go
+++ b/format/rfc5424.go
@@ -12,6 +12,10 @@ func (f *RFC5424) GetParser(line []byte) LogParser {
 	return &parserWrapper{rfc5424.NewParser(line)}
 }
 
+func (f *RFC5424) GetParserUnixSocket(line []byte) LogParser {
+	return f.GetParser(line)
+}
+
 func (f *RFC5424) GetSplitFunc() bufio.SplitFunc {
 	return nil
 }

--- a/format/rfc6587.go
+++ b/format/rfc6587.go
@@ -14,6 +14,10 @@ func (f *RFC6587) GetParser(line []byte) LogParser {
 	return &parserWrapper{rfc5424.NewParser(line)}
 }
 
+func (f *RFC6587) GetParserUnixSocket(line []byte) LogParser {
+	return f.GetParser(line)
+}
+
 func (f *RFC6587) GetSplitFunc() bufio.SplitFunc {
 	return rfc6587ScannerSplit
 }

--- a/internal/syslogparser/rfc3164/rfc3164.go
+++ b/internal/syslogparser/rfc3164/rfc3164.go
@@ -8,15 +8,16 @@ import (
 )
 
 type Parser struct {
-	buff     []byte
-	cursor   int
-	l        int
-	priority syslogparser.Priority
-	version  int
-	header   header
-	message  rfc3164message
-	location *time.Location
-	skipTag  bool
+	buff         []byte
+	cursor       int
+	l            int
+	priority     syslogparser.Priority
+	version      int
+	header       header
+	message      rfc3164message
+	location     *time.Location
+	skipTag      bool
+	skipHostname bool
 }
 
 type header struct {
@@ -29,12 +30,13 @@ type rfc3164message struct {
 	content string
 }
 
-func NewParser(buff []byte) *Parser {
+func NewParser(buff []byte, skipHostname bool) *Parser {
 	return &Parser{
-		buff:     buff,
-		cursor:   0,
-		l:        len(buff),
-		location: time.UTC,
+		buff:         buff,
+		cursor:       0,
+		l:            len(buff),
+		location:     time.UTC,
+		skipHostname: skipHostname,
 	}
 }
 
@@ -186,6 +188,9 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
 }
 
 func (p *Parser) parseHostname() (string, error) {
+	if p.skipHostname {
+		return "", nil
+	}
 	return syslogparser.ParseHostname(p.buff, &p.cursor, p.l)
 }
 

--- a/server.go
+++ b/server.go
@@ -250,7 +250,14 @@ loop:
 }
 
 func (s *Server) parser(line []byte, client string, tlsPeer string) {
-	parser := s.format.GetParser(line)
+	var parser format.LogParser
+
+	if client == "" {
+		parser = s.format.GetParserUnixSocket(line)
+	} else {
+		parser = s.format.GetParser(line)
+	}
+
 	err := parser.Parse()
 	if err != nil {
 		s.lastError = err


### PR DESCRIPTION
One way of taking care of it at least. I only changed RFC3164. Not sure if the other formats occur over unix sockets? Is perhaps something that should be configurable on the API side?

Some fragments wrt hostname history in Go's syslog can be found here:
https://github.com/golang/go/issues/5803

fixes #42 