### PR TITLE
 Add support for timestamp in RFC3339 format

### DIFF
--- a/internal/syslogparser/rfc3164/rfc3164.go
+++ b/internal/syslogparser/rfc3164/rfc3164.go
@@ -142,8 +142,16 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
 	var sub []byte
 
 	tsFmts := []string{
-		"Jan 02 15:04:05",
-		"Jan  2 15:04:05",
+		time.Stamp,
+		time.RFC3339,
+	}
+	// if timestamps starts with numeric try formats with different order
+	// it is more likely that timestamp is in RFC3339 format then
+	if c := p.buff[p.cursor]; c > '0' && c < '9' {
+		tsFmts = []string{
+			time.RFC3339,
+			time.Stamp,
+		}
 	}
 
 	found := false
@@ -163,7 +171,7 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
 	}
 
 	if !found {
-		p.cursor = tsFmtLen
+		p.cursor = len(time.Stamp)
 
 		// XXX : If the timestamp is invalid we try to push the cursor one byte
 		// XXX : further, in case it is a space


### PR DESCRIPTION
This fixes issue https://github.com/mcuadros/go-syslog/issues/45.

Default Go log/syslog is sending syslog messages in that [format](https://github.com/golang/go/blob/9745eed4fd4160cfbf55e9dbbfa99aca5563b392/src/log/syslog/syslog.go#L294).
That is not according to the [standard](https://tools.ietf.org/html/rfc3164#section-5.3):
"The TIMESTAMP field is the local time and is in the format of "Mmm dd hh:mm:ss" (without the quote marks)"
But it is necessery if we want to parse lines sent by log/syslog.