### PR TITLE
server: add generic listen function

### DIFF
--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -92,9 +93,27 @@ func (s *Server) ListenUDP(addr string) error {
 	if err != nil {
 		return err
 	}
-	connection.SetReadBuffer(datagramReadBufferSize)
 
-	s.connections = append(s.connections, connection)
+	return s.listenUDP(connection)
+}
+
+func (s *Server) listenUDP(conn *net.UDPConn) error {
+	conn.SetReadBuffer(datagramReadBufferSize)
+
+	s.connections = append(s.connections, conn)
+	return nil
+}
+
+//ListenOn user defined socket
+func (s *Server) ListenOn(conn interface{}) error {
+	switch c := conn.(type) {
+	case *net.UDPConn:
+		return s.listenUDP(c)
+	case *net.UnixConn:
+		return s.listenUnixgram(c)
+	default:
+		return fmt.Errorf("unknown socket type")
+	}
 	return nil
 }
 
@@ -109,9 +128,14 @@ func (s *Server) ListenUnixgram(addr string) error {
 	if err != nil {
 		return err
 	}
-	connection.SetReadBuffer(datagramReadBufferSize)
 
-	s.connections = append(s.connections, connection)
+	return s.listenUnixgram(connection)
+}
+
+func (s *Server) listenUnixgram(conn *net.UnixConn) error {
+	conn.SetReadBuffer(datagramReadBufferSize)
+
+	s.connections = append(s.connections, conn)
 	return nil
 }
 


### PR DESCRIPTION
Hey,

I guess it is nice to have a generic listen function because go1.11+ now has `ListenConfig` methods and it could be useful to setup some sockets options. For example:
```go
func controlSetOpts(network, address string, c syscall.RawConn) (err error) {
	// Taken from /usr/include/asm-generic/socket.h
	const reuseport = 15
	return c.Control(func(fd uintptr) {
		// Try to set socket options ..
		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
			log.Printf("cannot set SO_REUSEADDR on fd [%d]: %s", fd, err)
		}
		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, reuseport, 1); err != nil {
			log.Printf("cannot set SO_REUSEPORT on fd [%d]: %s", fd, err)
		}
	})
}
...

lc := &net.ListenConfig{Control: controlSetOpts}
if conn, err := lc.ListenPacket(context.Background(), "udp", "127.0.0.1:7788"); err != nil {
	return err
} else {
	err = syslog.ListenOn(conn)
}
```

Any comments are welcome!