### PR TITLE
Ensure server does not panic when Kill is called

### DIFF
--- a/server.go
+++ b/server.go
@@ -336,7 +336,12 @@ func (s *Server) goReceiveDatagrams(packetconn net.PacketConn) {
 					if addr != nil {
 						address = addr.String()
 					}
-					s.datagramChannel <- DatagramMessage{buf[:n], address}
+					func() { // Ensure server does not panic on close channel when Kill() is called
+						defer func() {
+							recover()
+						}()
+						s.datagramChannel <- DatagramMessage{buf[:n], address}
+					}()
 				}
 			} else {
 				// there has been an error. Either the server has been killed


### PR DESCRIPTION
The datagram channel is closed without synchronization, thus the reading
routine is exposed to a race condition that crashes the channel. As the
crash is sporadic, it's not easily reproducible in test, but sending
multiple packets during shutdown causes the crash.

An alternative solution is do synchronize using a done channel:
https://blog.golang.org/pipelines

Signed-off-by: liron <liron@twistlock.com>