### PR TITLE
support for no priority as specified in rfc3164 section 4.3.3

### DIFF
--- a/internal/syslogparser/rfc3164/rfc3164.go
+++ b/internal/syslogparser/rfc3164/rfc3164.go
@@ -43,12 +43,21 @@ func (p *Parser) Location(location *time.Location) {
 }
 
 func (p *Parser) Parse() error {
+	tcursor := p.cursor
 	pri, err := p.parsePriority()
 	if err != nil {
-		return err
+		// RFC3164 sec 4.3.3
+		p.priority = syslogparser.Priority{13, syslogparser.Facility{Value: 1}, syslogparser.Severity{Value: 5}}
+		p.cursor = tcursor
+		content, err := p.parseContent()
+		if err != syslogparser.ErrEOL {
+			return err
+		}
+		p.message = rfc3164message{content: content}
+		return nil
 	}
 
-	tcursor := p.cursor
+	tcursor = p.cursor
 	hdr, err := p.parseHeader()
 	if err == syslogparser.ErrTimestampUnknownFormat {
 		// RFC3164 sec 4.3.2.

--- a/internal/syslogparser/rfc3164/rfc3164.go
+++ b/internal/syslogparser/rfc3164/rfc3164.go
@@ -50,6 +50,7 @@ func (p *Parser) Parse() error {
 		p.priority = syslogparser.Priority{13, syslogparser.Facility{Value: 1}, syslogparser.Severity{Value: 5}}
 		p.cursor = tcursor
 		content, err := p.parseContent()
+		p.header.timestamp = time.Now().Round(time.Second)
 		if err != syslogparser.ErrEOL {
 			return err
 		}

--- a/internal/syslogparser/rfc3164/rfc3164_test.go
+++ b/internal/syslogparser/rfc3164/rfc3164_test.go
@@ -121,6 +121,40 @@ func (s *Rfc3164TestSuite) TestParser_NoTimestamp(c *C) {
 	c.Assert(obtained, DeepEquals, expected)
 }
 
+// RFC 3164 section 4.3.3
+func (s *Rfc3164TestSuite) TestParser_NoPriority(c *C) {
+	buff := []byte("Oct 11 22:14:15 Testing no priority")
+
+	p := NewParser(buff)
+	expectedP := &Parser{
+		buff:     buff,
+		cursor:   0,
+		l:        len(buff),
+		location: time.UTC,
+	}
+
+	c.Assert(p, DeepEquals, expectedP)
+
+	err := p.Parse()
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+
+	obtained := p.Dump()
+	obtained["timestamp"] = now // XXX: Need to mock out time to test this fully
+	expected := syslogparser.LogParts{
+		"timestamp": now,
+		"hostname":  "",
+		"tag":       "",
+		"content":   "Oct 11 22:14:15 Testing no priority",
+		"priority":  13,
+		"facility":  1,
+		"severity":  5,
+	}
+
+	c.Assert(obtained, DeepEquals, expected)
+}
+
 func (s *Rfc3164TestSuite) TestParseHeader_Valid(c *C) {
 	buff := []byte("Oct 11 22:14:15 mymachine ")
 	now := time.Now()

--- a/internal/syslogparser/rfc3164/rfc3164_test.go
+++ b/internal/syslogparser/rfc3164/rfc3164_test.go
@@ -107,6 +107,10 @@ func (s *Rfc3164TestSuite) TestParser_NoTimestamp(c *C) {
 	now := time.Now()
 
 	obtained := p.Dump()
+
+	obtainedTime := obtained["timestamp"].(time.Time)
+	s.assertTimeIsCloseToNow(c, obtainedTime)
+
 	obtained["timestamp"] = now // XXX: Need to mock out time to test this fully
 	expected := syslogparser.LogParts{
 		"timestamp": now,
@@ -141,6 +145,9 @@ func (s *Rfc3164TestSuite) TestParser_NoPriority(c *C) {
 	now := time.Now()
 
 	obtained := p.Dump()
+	obtainedTime := obtained["timestamp"].(time.Time)
+	s.assertTimeIsCloseToNow(c, obtainedTime)
+
 	obtained["timestamp"] = now // XXX: Need to mock out time to test this fully
 	expected := syslogparser.LogParts{
 		"timestamp": now,
@@ -408,4 +415,12 @@ func (s *Rfc3164TestSuite) assertRfc3164message(c *C, msg rfc3164message, b []by
 	c.Assert(err, Equals, e)
 	c.Assert(obtained, Equals, msg)
 	c.Assert(p.cursor, Equals, expC)
+}
+
+func (s *Rfc3164TestSuite) assertTimeIsCloseToNow(c *C, obtainedTime time.Time) {
+	now := time.Now()
+	timeStart := now.Add(-(time.Second * 5))
+	timeEnd := now.Add(time.Second)
+	c.Assert(obtainedTime.After(timeStart), Equals, true)
+	c.Assert(obtainedTime.Before(timeEnd), Equals, true)
 }

--- a/server.go
+++ b/server.go
@@ -258,7 +258,7 @@ func (s *Server) parser(line []byte, client string, tlsPeer string) {
 
 	logParts := parser.Dump()
 	logParts["client"] = client
-	if logParts["hostname"] == "" && s.format == RFC3164 {
+	if logParts["hostname"] == "" && (s.format == RFC3164 || s.format == Automatic) {
 		if i := strings.Index(client, ":"); i > 1 {
 			logParts["hostname"] = client[:i]
 		} else {


### PR DESCRIPTION
rfc3164 section 4.3.3 allows sending messages without the priority prefix. See: https://tools.ietf.org/html/rfc3164#section-4.3.3 . This PR adds support for the case that no priority is specified. It affects both working in automatic and rfc3164 modes.