### PR TITLE
Add bounds checks to rfc5424 parser

### DIFF
--- a/internal/syslogparser/rfc5424/rfc5424.go
+++ b/internal/syslogparser/rfc5424/rfc5424.go
@@ -193,6 +193,10 @@ func (p *Parser) parseVersion() (int, error) {
 func (p *Parser) parseTimestamp() (time.Time, error) {
 	var ts time.Time
 
+	if p.cursor >= p.l {
+		return ts, ErrInvalidTimeFormat
+	}
+
 	if p.buff[p.cursor] == NILVALUE {
 		p.cursor++
 		return ts, nil
@@ -203,7 +207,7 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
 		return ts, err
 	}
 
-	if p.buff[p.cursor] != 'T' {
+	if p.cursor >= p.l || p.buff[p.cursor] != 'T' {
 		return ts, ErrInvalidTimeFormat
 	}
 
@@ -272,7 +276,7 @@ func parseFullDate(buff []byte, cursor *int, l int) (fullDate, error) {
 		return fd, err
 	}
 
-	if buff[*cursor] != '-' {
+	if *cursor >= l || buff[*cursor] != '-' {
 		return fd, syslogparser.ErrTimestampUnknownFormat
 	}
 
@@ -283,7 +287,7 @@ func parseFullDate(buff []byte, cursor *int, l int) (fullDate, error) {
 		return fd, err
 	}
 
-	if buff[*cursor] != '-' {
+	if *cursor >= l || buff[*cursor] != '-' {
 		return fd, syslogparser.ErrTimestampUnknownFormat
 	}
 
@@ -371,7 +375,7 @@ func parsePartialTime(buff []byte, cursor *int, l int) (partialTime, error) {
 		return pt, err
 	}
 
-	if buff[*cursor] != ':' {
+	if *cursor >= l || buff[*cursor] != ':' {
 		return pt, ErrInvalidTimeFormat
 	}
 
@@ -392,7 +396,7 @@ func parsePartialTime(buff []byte, cursor *int, l int) (partialTime, error) {
 
 	// ----
 
-	if buff[*cursor] != '.' {
+	if *cursor >= l || buff[*cursor] != '.' {
 		return pt, nil
 	}
 
@@ -458,7 +462,7 @@ func parseSecFrac(buff []byte, cursor *int, l int) (float64, error) {
 // TIME-OFFSET = "Z" / TIME-NUMOFFSET
 func parseTimeOffset(buff []byte, cursor *int, l int) (*time.Location, error) {
 
-	if buff[*cursor] == 'Z' {
+	if *cursor >= l || buff[*cursor] == 'Z' {
 		*cursor++
 		return time.UTC, nil
 	}
@@ -498,7 +502,7 @@ func getHourMinute(buff []byte, cursor *int, l int) (int, int, error) {
 		return 0, 0, err
 	}
 
-	if buff[*cursor] != ':' {
+	if *cursor >= l || buff[*cursor] != ':' {
 		return 0, 0, ErrInvalidTimeFormat
 	}
 
@@ -588,8 +592,8 @@ func parseUpToLen(buff []byte, cursor *int, l int, maxLen int, e error) (string,
 
 	if found {
 		result = string(buff[*cursor:to])
-	} else if (to > max) {
-		to = max; // don't go past max
+	} else if to > max {
+		to = max // don't go past max
 	}
 
 	*cursor = to

--- a/internal/syslogparser/rfc5424/rfc5424_test.go
+++ b/internal/syslogparser/rfc5424/rfc5424_test.go
@@ -137,6 +137,14 @@ func (s *Rfc5424TestSuite) TestParser_Valid(c *C) {
 	}
 }
 
+func (s *Rfc5424TestSuite) TestParser_Truncated(c *C) {
+	msg := "<165>1 2003-08-24T05:14:15.000003-07:00 192.0.2.1 myproc 8710 - - %% It's time to make the do-nuts."
+	for i := range msg {
+		p := NewParser([]byte(msg[:i]))
+		p.Parse()
+	}
+}
+
 func (s *Rfc5424TestSuite) TestParseHeader_Valid(c *C) {
 	ts := time.Date(2003, time.October, 11, 22, 14, 15, 3*10e5, time.UTC)
 	tsString := "2003-10-11T22:14:15.003Z"
@@ -291,6 +299,13 @@ func (s *Rfc5424TestSuite) TestParseTimestamp_NilValue(c *C) {
 	ts := new(time.Time)
 
 	s.assertTimestamp(c, *ts, buff, 1, nil)
+}
+
+func (s *Rfc5424TestSuite) TestParseTimestamp_Empty(c *C) {
+	buff := []byte("")
+	ts := new(time.Time)
+
+	s.assertTimestamp(c, *ts, buff, 0, ErrInvalidTimeFormat)
 }
 
 func (s *Rfc5424TestSuite) TestFindNextSpace_NoSpace(c *C) {

--- a/internal/syslogparser/syslogparser.go
+++ b/internal/syslogparser/syslogparser.go
@@ -28,6 +28,8 @@ var (
 	ErrVersionNotFound = &ParserError{"Can not find version"}
 
 	ErrTimestampUnknownFormat = &ParserError{"Timestamp format unknown"}
+
+	ErrHostnameTooShort = &ParserError{"Hostname field too short"}
 )
 
 type LogParser interface {
@@ -180,6 +182,11 @@ func Parse2Digits(buff []byte, cursor *int, l int, min int, max int, e error) (i
 
 func ParseHostname(buff []byte, cursor *int, l int) (string, error) {
 	from := *cursor
+
+	if from >= l {
+		return "", ErrHostnameTooShort
+	}
+
 	var to int
 
 	for to = from; to < l; to++ {


### PR DESCRIPTION
Hello,

We're streaming logs via syslog from our CDN provider, and sometimes the server crashes with "out of range panic":

```
panic: runtime error: index out of range

goroutine 243 [running]:
gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc5424.(*Parser).parseTimestamp(0xc000704c00, 0x1, 0x0, 0x0, 0x0, 0x0)
        /go/pkg/mod/gopkg.in/mcuadros/go-syslog.v2@v2.2.1/internal/syslogparser/rfc5424/rfc5424.go:196 +0x39d
gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc5424.(*Parser).parseHeader(0xc000704c00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /go/pkg/mod/gopkg.in/mcuadros/go-syslog.v2@v2.2.1/internal/syslogparser/rfc5424/rfc5424.go:141 +0x107
gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc5424.(*Parser).Parse(0xc000704c00, 0xc000b58900, 0xc000704c00)
        /go/pkg/mod/gopkg.in/mcuadros/go-syslog.v2@v2.2.1/internal/syslogparser/rfc5424/rfc5424.go:85 +0x71
gopkg.in/mcuadros/go-syslog%2ev2.(*Server).parser(0xc00014e580, 0xc00080e5a8, 0x7, 0x8, 0xc0002a0be0, 0x10, 0x0, 0x0)
        /go/pkg/mod/gopkg.in/mcuadros/go-syslog.v2@v2.2.1/server.go:254 +0x8e
gopkg.in/mcuadros/go-syslog%2ev2.(*Server).scan(0xc00014e580, 0xc0003825c0, 0xc0002a0be0, 0x10, 0x0, 0x0)
        /go/pkg/mod/gopkg.in/mcuadros/go-syslog.v2@v2.2.1/server.go:242 +0xd8
created by gopkg.in/mcuadros/go-syslog%2ev2.(*Server).goScanConnection
        /go/pkg/mod/gopkg.in/mcuadros/go-syslog.v2@v2.2.1/server.go:227 +0x272
```

It could be caused by our network, not CDN, but in any case we would like to prevent crashing and gracefully error out.

I fixed the panic mentioned above with an explicit test `TestParseTimestamp_Empty`. Then I added a test that feeds truncated messages to the panic and prevented corresponding panics.

Please let me know if anything needs to be changed.