### PR TITLE
Fix GNU syslog

### DIFF
--- a/format/rfc3164_test.go
+++ b/format/rfc3164_test.go
@@ -21,6 +21,18 @@ func (s *FormatSuite) TestRFC3164_CorrectParsingTypical(c *C) {
 	c.Assert(parser.Dump()["tag"], Equals, "myprogram")
 
 }
+func (s *FormatSuite) TestRFC3164_CorrectParsingTypicalWithPID(c *C) {
+	f := RFC3164{}
+
+	find := `<13>May  1 20:51:40 myhostname myprogram[42]: ciao`
+	parser := f.GetParser([]byte(find))
+	err := parser.Parse()
+	c.Assert(err, IsNil)
+	c.Assert(parser.Dump()["content"], Equals, "ciao")
+	c.Assert(parser.Dump()["hostname"], Equals, "myhostname")
+	c.Assert(parser.Dump()["tag"], Equals, "myprogram")
+
+}
 
 func (s *FormatSuite) TestRFC3164_CorrectParsingGNU(c *C) {
 	// GNU implementation of syslog() has a variant: hostname is missing

--- a/format/rfc3164_test.go
+++ b/format/rfc3164_test.go
@@ -12,10 +12,8 @@ func (s *FormatSuite) TestRFC3164_SingleSplit(c *C) {
 func (s *FormatSuite) TestRFC3164_CorrectParsingTypical(c *C) {
 	f := RFC3164{}
 
-	find := []string{
-		`<13>May  1 20:51:40 myhostname myprogram: ciao`,
-	}
-	parser := f.GetParser([]byte(find[0]))
+	find := `<13>May  1 20:51:40 myhostname myprogram: ciao`
+	parser := f.GetParser([]byte(find))
 	err := parser.Parse()
 	c.Assert(err, IsNil)
 	c.Assert(parser.Dump()["content"], Equals, "ciao")
@@ -24,18 +22,31 @@ func (s *FormatSuite) TestRFC3164_CorrectParsingTypical(c *C) {
 
 }
 
-func (s *FormatSuite) TestRFC3164_CorrectParsingGnu(c *C) {
+func (s *FormatSuite) TestRFC3164_CorrectParsingGNU(c *C) {
 	// GNU implementation of syslog() has a variant: hostname is missing
 	f := RFC3164{}
 
-	find := []string{
-		`<13>May  1 20:51:40 myprogram: ciao`,
-	}
-	parser := f.GetParser([]byte(find[0]))
+	find := `<13>May  1 20:51:40 myprogram: ciao`
+	parser := f.GetParser([]byte(find))
 	err := parser.Parse()
 	c.Assert(err, IsNil)
 	c.Assert(parser.Dump()["content"], Equals, "ciao")
 	// c.Assert(parser.Dump()["hostname"], Equals, "myhostname")
 	c.Assert(parser.Dump()["tag"], Equals, "myprogram")
+
+}
+
+func (s *FormatSuite) TestRFC3164_CorrectParsingJournald(c *C) {
+	// GNU implementation of syslog() has a variant: hostname is missing
+	// systemd uses it, and typically also passes PID
+	f := RFC3164{}
+
+	find := `<78>May  1 20:51:02 myprog[153]: blah`
+	parser := f.GetParser([]byte(find))
+	err := parser.Parse()
+	c.Assert(err, IsNil)
+	c.Assert(parser.Dump()["content"], Equals, "blah")
+	// c.Assert(parser.Dump()["hostname"], Equals, "myhostname")
+	c.Assert(parser.Dump()["tag"], Equals, "myprog")
 
 }

--- a/format/rfc3164_test.go
+++ b/format/rfc3164_test.go
@@ -8,3 +8,34 @@ func (s *FormatSuite) TestRFC3164_SingleSplit(c *C) {
 	f := RFC3164{}
 	c.Assert(f.GetSplitFunc(), IsNil)
 }
+
+func (s *FormatSuite) TestRFC3164_CorrectParsingTypical(c *C) {
+	f := RFC3164{}
+
+	find := []string{
+		`<13>May  1 20:51:40 myhostname myprogram: ciao`,
+	}
+	parser := f.GetParser([]byte(find[0]))
+	err := parser.Parse()
+	c.Assert(err, IsNil)
+	c.Assert(parser.Dump()["content"], Equals, "ciao")
+	c.Assert(parser.Dump()["hostname"], Equals, "myhostname")
+	c.Assert(parser.Dump()["tag"], Equals, "myprogram")
+
+}
+
+func (s *FormatSuite) TestRFC3164_CorrectParsingGnu(c *C) {
+	// GNU implementation of syslog() has a variant: hostname is missing
+	f := RFC3164{}
+
+	find := []string{
+		`<13>May  1 20:51:40 myprogram: ciao`,
+	}
+	parser := f.GetParser([]byte(find[0]))
+	err := parser.Parse()
+	c.Assert(err, IsNil)
+	c.Assert(parser.Dump()["content"], Equals, "ciao")
+	// c.Assert(parser.Dump()["hostname"], Equals, "myhostname")
+	c.Assert(parser.Dump()["tag"], Equals, "myprogram")
+
+}


### PR DESCRIPTION
The current implementation doesn't seem to work with GNU syslog()

I have especially tested its integration with `systemd-journald`, and I'm not getting messages from `/run/systemd/journal/syslog` correctly.

The error appears to be in the fact that GNU syslog() (and therefore, journald) omits the hostname from their messages.

My patch understands this case, and assumes it is a local message in that case.

I also added unit tests to ensure that both "normal" 3164 messages and GNU variant is working correctly.