### PR TITLE
Fixes unit tests under go 1.16, fix for UTC timestamp parsing, adds go modules support

### DIFF
--- a/format/rfc3164_test.go
+++ b/format/rfc3164_test.go
@@ -34,6 +34,19 @@ func (s *FormatSuite) TestRFC3164_CorrectParsingTypicalWithPID(c *C) {
 
 }
 
+func (s *FormatSuite) TestRFC3164_CorrectParsingGoSyslogUTC(c *C) {
+	f := RFC3164{}
+	// example of go's builtin syslog logging compiled with 1.16.3 on host using UTC
+	find := "<30>2021-05-02T23:54:09Z myhostname mytag[488]: message"
+	parser := f.GetParser([]byte(find))
+	err := parser.Parse()
+	c.Assert(err, IsNil)
+	c.Assert(parser.Dump()["content"], Equals, "message")
+	c.Assert(parser.Dump()["hostname"], Equals, "myhostname")
+	c.Assert(parser.Dump()["tag"], Equals, "mytag")
+
+}
+
 func (s *FormatSuite) TestRFC3164_CorrectParsingGNU(c *C) {
 	// GNU implementation of syslog() has a variant: hostname is missing
 	f := RFC3164{}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module gopkg.in/mcuadros/go-syslog.v2
+
+go 1.14
+
+require gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/syslogparser/rfc3164/rfc3164.go
+++ b/internal/syslogparser/rfc3164/rfc3164.go
@@ -167,7 +167,14 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
 
 	found := false
 	for _, tsFmt := range tsFmts {
-		tsFmtLen = len(tsFmt)
+		if tsFmt == time.RFC3339 {
+			tsFmtLen = bytes.IndexByte(p.buff[p.cursor:], ' ')
+			if tsFmtLen == -1 {
+				continue
+			}
+		} else {
+			tsFmtLen = len(tsFmt)
+		}
 
 		if p.cursor+tsFmtLen > p.l {
 			continue

--- a/servertls_test.go
+++ b/servertls_test.go
@@ -4,8 +4,6 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
-	"io"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -13,11 +11,11 @@ import (
 
 func getServerConfig() *tls.Config {
 	capool := x509.NewCertPool()
-	if ok := capool.AppendCertsFromPEM([]byte(ca_s)); !ok {
+	if ok := capool.AppendCertsFromPEM([]byte(caCertPEM)); !ok {
 		panic("Cannot add cert")
 	}
 
-	cert, err := tls.X509KeyPair([]byte(cert1_s), []byte(priv1_s))
+	cert, err := tls.X509KeyPair([]byte(serverCertPEM), []byte(serverKeyPEM))
 	if err != nil {
 		panic(err)
 	}
@@ -27,18 +25,17 @@ func getServerConfig() *tls.Config {
 		Certificates: []tls.Certificate{cert},
 		ClientCAs:    capool,
 	}
-	config.Rand = rand.Reader
 
 	return &config
 }
 
 func getClientConfig() *tls.Config {
 	capool := x509.NewCertPool()
-	if ok := capool.AppendCertsFromPEM([]byte(ca_s)); !ok {
+	if ok := capool.AppendCertsFromPEM([]byte(caCertPEM)); !ok {
 		panic("Cannot add cert")
 	}
 
-	cert, err := tls.X509KeyPair([]byte(cert1_s), []byte(priv1_s))
+	cert, err := tls.X509KeyPair([]byte(clientCertPEM), []byte(clientKeyPEM))
 	if err != nil {
 		panic(err)
 	}
@@ -46,7 +43,7 @@ func getClientConfig() *tls.Config {
 	config := tls.Config{
 		Certificates:       []tls.Certificate{cert},
 		InsecureSkipVerify: false,
-		ServerName:         "dummycert1",
+		ServerName:         "localhost",
 		RootCAs:            capool,
 	}
 	config.Rand = rand.Reader
@@ -59,150 +56,212 @@ func (s *ServerSuite) TestTLS(c *C) {
 	server := NewServer()
 	server.SetFormat(RFC3164)
 	server.SetHandler(handler)
-	server.ListenTCPTLS("0.0.0.0:5143", getServerConfig())
+	err := server.ListenTCPTLS("127.0.0.1:0", getServerConfig())
+	c.Assert(err, IsNil)
+	serverAddr := server.listeners[0].Addr().String()
 
-	server.Boot()
+	err = server.Boot()
+	c.Assert(err, IsNil)
+
 	go func(server *Server) {
-		time.Sleep(100 * time.Millisecond)
-		conn, err := tls.Dial("tcp", "127.0.0.1:5143", getClientConfig())
-		if err != nil {
-			panic(err)
-		}
+		time.Sleep(100 * time.Millisecond) // give server time to start
+		conn, err := tls.Dial("tcp", serverAddr, getClientConfig())
+		c.Assert(err, IsNil)
 		defer conn.Close()
 
-		if _, err := io.WriteString(conn, fmt.Sprintf("%s\n", exampleSyslog)); err != nil {
-			panic(err)
-		}
-		server.Kill()
+		_, err = conn.Write([]byte(exampleSyslog + "\n"))
+		c.Assert(err, IsNil)
+		time.Sleep(100 * time.Millisecond) // give server time to process request
+		err = server.Kill()
+		c.Assert(err, IsNil)
 	}(server)
 	server.Wait()
 
 	c.Check(handler.LastLogParts["hostname"], Equals, "hostname")
 	c.Check(handler.LastLogParts["tag"], Equals, "tag")
 	c.Check(handler.LastLogParts["content"], Equals, "content")
-	c.Check(handler.LastLogParts["tls_peer"], Equals, "dummycert1")
+	c.Check(handler.LastLogParts["tls_peer"], Equals, "client")
 	c.Check(handler.LastMessageLength, Equals, int64(len(exampleSyslog)))
 	c.Check(handler.LastError, IsNil)
 }
 
 const (
-	priv1_s = `-----BEGIN RSA PRIVATE KEY-----
-MIIJKAIBAAKCAgEAxUfRcXt1/H6dWtHseq70x+VyrIj+4g+zjCa0UrdEUR8QQavO
-DTDUBuQmeASU40AnCO24Cnx0y7Kt6ZHrf3K9xI17aJj9qvE+9qQpfg+YMHFOFFuA
-AANKDcl3rmifwwo+hWB6DQRqD/CNACAFCez4W4O0+sETl/LbUkMw5I7ImKli1mlL
-PMfrId9ezOvyfWHZEQHRyDYBCkYsZDLW2mMySOJy1r1l4azIhshUcrDT+gBZHiyi
-81g2BS6n60O0xBHwiHSGvTpBTwXLpvJ44HeG4rJjRz9TMD2c+XrIeZWXsM7xAqMg
-F4uK2lUDSHM+1RBgQyJTMDodspSJQOz1Fc83Sze1Nyq9hprZo9/U5J+ML75Cumd9
-kDr1NF2hBk+49uDJtaU3czxexGN1p24hmTmJpnd6fvJ1hOZadX34DaluF7NXGXEO
-odMB6ggGqNNcHfws1Q5Xuyk6skwXtgWHLWdlygGYJ2qfj9l0F/gVDknjBubMIdrp
-JakkMvCXcGlqw+paIXQZMBQquwlrsesD+/YGEmVHvREGJsnXa8XHiTje1xKBPw5L
-sn/eY3f787NCy5atNlGPGtPY5IL2oiNMtHCOH9fufBTswR0ch0ZUoR109NjDw2EU
-ye0YOQ8B0uJyrva/aM0l/DH+ieXCAN4sxnyYN3yfo3J8nh4Hq/n22K8gZO8CAwEA
-AQKCAgAmz4svtScwBkS0oknQlOzJCqW1tbnXBVnAP7kH8M/62Y6cLM17oNiFhore
-35/e2TcUtZeYUIW1sTAvnCplR1B4A5F8sWRuJcnKQd970luRZCkFLj8PQZZnAfSO
-ljyf5TsJiEJanzyyaBOFK8dx/XGap12KW0OciAWHuHo87K4gAmrUXaCUk4v5fPUs
-gVqSOha3FtGLfrxTphyDldDY49z3o70N6/LII/LLOUwLyCfbrgfaPNPN5dOyz0vv
-p8E/NXxJjAsZ3QUOI8i9zkPjfQBHRurrEFUwT167YeFgsgJGoV+esjLVDvnBHCpq
-LWn2BqO5cV5GRZikEj6yTCunH73zsInZuoZU8w1KnKbynRKCRBNs1lst3GP7Qp6S
-yMLXKlVGb9LREJZ119RxKig6GMx+9NkfFfD11kle3YQYk0OF6FG62SMGLZeEcB7Z
-cSFE0igw6A1jI3NljhiXoRbLIX/ls/3mzxnQojpNb0vYw0ob21RzaAhKeoRHYWcx
-BKklmhSfKTqNfAqa9M2kU0uZI+mFaFbPUwyTznf0xyzguB62HxA9M1HPI3k4TrDq
-w4U2aDxyUlDq9jbD48MUPKwyCTmQYM3IDGfaOd5aziGpgYHlwt0dvXESEHXzFPko
-PlgNK9bLO+1rdZlvHvQd0x+5P4Q5skSKPpwQ6lquO3CMAMn1uQKCAQEA88B2wF3n
-VjyB0xyE5ZGnAKfTwSwTOpMRF9smCx2epwuxZn5zPoeORtgLyGVifVhyK256Fbvz
-tflgY9gAbFGWIzzoyj0SQWTR4iVt3Gdh3h+BzljDoWld5KyNubr6NKSEfA3Z9HMv
-QpsEmeEJl3RjA0PyyBP8JSEGYqjXUC9/PtDC9NgUJYXd3to4HsTvV+Prh45OwTZo
-wDIsyXTMPDBS1i31fv4rHm6ff8LXFLx6RuUC0w4EabGyHkUIlPsCzI75bv1Dzcsn
-rWNIj4KI2jgnR5xCnQriImgiFwKQ4QK525t2N66/VDUD0ZkmGXCFb0HBioazXDXt
-B/2iW4nt9t+AGwKCAQEAzzGQfwW0uXXECK2qmiCrmIA3cm9Y1ThZMFUCDkn6L3K/
-gKN/mKpPGrlEY6/wG5ZVm6/Pbd6QEnjtGFGwchq3N1q3xca2nOC+ApcoQs+Gsm8I
-tOup0YL1gO4msbBbnmRxJZrtAJ1w7f78qTZrcp5Pl61MqztADkXP2rPqfXrXUexY
-XViu/elJbnaHa4zlHVDs8x/fklmag819HJNj/mF4tDUFn0lZm4cARfQu+iO3KaRe
-zeH6YDDiZ2ojmRKEzEq6lgL5Sq/46IjDhP5NBBaYYNPwJTdnnMf3JDseWshD+aT9
-Er4TSb61Onn4OslkJvtg1EoM/naDh1gULgG0+8ODvQKCAQAxjlOWUIET20FZtlae
-hbo6O+SlRVyzb+rturRFVkRHGe17NQIhGFYouQvMNjCL40ty4QcZHBk0Sfr60ZNk
-ckHf8CYz1666dNDm9U0cnjgbfLRbS1ianF1mfF5kAEuWIEx/HCHPvQtCs1mAH2xf
-yl3G8C2P1+BPfCNcM49y0fVAxBiexr9x0YGGKT93ofo3GDNuX9RLG9C4IntQidpr
-8jclLDrZEruZeEwdIXOw15DUkQK9/f+PrXzVApv4DgBHrlmv4vXCBSeP7Lt30cYY
-94mk2XQBkZDgBePIYdEqre8zYqvqLjDf4ddg6Y4BZgr6z5eVnkUg3iXOlhZIHgav
-Rkk5AoIBAEmowkkWOzjP0ECRlRw0TyzpME0jnr42ySZwokl4LVSfA8v01FDvAy5p
-/RE/pCn6mTa/GwxhWnDmwsuphwQZ0VcBjmHmkldVYtfC61JNOwLGjJ7dRUMxvpv2
-jpUPMJMv/DW1TVqxnktOIn751NsrwvoWZzJc3xnz4cBLxCqV+GSslIGjHJsyS6PU
-ybIHphB1C7gndbEu38rJzBfTonH2LxZJ31TQm+W56fP0qprNBbntMLMbCosV9fdz
-+XHa7pE+Y/Ue24ec5e2taW0nhzPT4JpT3oUsnE5VnNwplFIL7nabHEmEf5DxFrbS
-U9h6bnuZVMRECziP45TDUHFGtBPpXzUCggEBAOwx+xPlAfkn80hIj41uyAG9DLUA
-ZOdTzEG4qJN4cjp2HTFJAq+FaD6fCGrmKu72ycqjWvNFvZ8IWjvyGvpWNn+DJcZB
-EyL95Nn22xZS1yIorCSZVFsU/2eh8pveuNlaEJzYZiQnwpnG8cjLViLJ2wFqQpui
-Vf8mYY5HIi926EmP61+OKnn8yiKE0d7l+YCsGLZnDdw8Y1Sa5nJsnZjwzOeKOwUz
-ZJJDP6VXWQSsnBUPrDdmla15BGvWPmXV4vY/Sw632W/MZpdXJ4tGYOr4RLrN/w19
-nuuSJKSK3k/2CckB7KEpy7ADcX7Hh/5wc6v2J84tYvm0KQPBD6WBEiyxI2Y=
------END RSA PRIVATE KEY-----`
-
-	cert1_s = `-----BEGIN CERTIFICATE-----
-MIIFYDCCA0igAwIBAgIBATANBgkqhkiG9w0BAQUFADBbMQswCQYDVQQGEwJYWDEN
-MAsGA1UECBMETm9uZTENMAsGA1UEBxMETm9uZTENMAsGA1UEChMETm9uZTENMAsG
-A1UECxMETm9uZTEQMA4GA1UEAxMHZHVtbXljYTAgFw0xNTA3MTYxNzQzMzBaGA8y
-MTE1MDYyMjE3NDMzMFowTzELMAkGA1UEBhMCWFgxDTALBgNVBAgTBE5vbmUxDTAL
-BgNVBAoTBE5vbmUxDTALBgNVBAsTBE5vbmUxEzARBgNVBAMTCmR1bW15Y2VydDEw
-ggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDFR9Fxe3X8fp1a0ex6rvTH
-5XKsiP7iD7OMJrRSt0RRHxBBq84NMNQG5CZ4BJTjQCcI7bgKfHTLsq3pket/cr3E
-jXtomP2q8T72pCl+D5gwcU4UW4AAA0oNyXeuaJ/DCj6FYHoNBGoP8I0AIAUJ7Phb
-g7T6wROX8ttSQzDkjsiYqWLWaUs8x+sh317M6/J9YdkRAdHINgEKRixkMtbaYzJI
-4nLWvWXhrMiGyFRysNP6AFkeLKLzWDYFLqfrQ7TEEfCIdIa9OkFPBcum8njgd4bi
-smNHP1MwPZz5esh5lZewzvECoyAXi4raVQNIcz7VEGBDIlMwOh2ylIlA7PUVzzdL
-N7U3Kr2Gmtmj39Tkn4wvvkK6Z32QOvU0XaEGT7j24Mm1pTdzPF7EY3WnbiGZOYmm
-d3p+8nWE5lp1ffgNqW4Xs1cZcQ6h0wHqCAao01wd/CzVDle7KTqyTBe2BYctZ2XK
-AZgnap+P2XQX+BUOSeMG5swh2uklqSQy8JdwaWrD6lohdBkwFCq7CWux6wP79gYS
-ZUe9EQYmyddrxceJON7XEoE/Dkuyf95jd/vzs0LLlq02UY8a09jkgvaiI0y0cI4f
-1+58FOzBHRyHRlShHXT02MPDYRTJ7Rg5DwHS4nKu9r9ozSX8Mf6J5cIA3izGfJg3
-fJ+jcnyeHger+fbYryBk7wIDAQABozkwNzAJBgNVHRMEAjAAMAsGA1UdDwQEAwIF
-4DAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQEFBQAD
-ggIBAFCfYO/WpS/2rTp+VUoGvVJmpNfM2mXmo2mPb0KiEQ2tl6aIbdc7XAR3DIvf
-CMi919iW3wcMoe2XAMmZFXnGOYcb1x5mVqiHJdkJZonIDlhEJmEiVXL1FNrRNMia
-8sFkZPH3opE3nDpSEc9sXgWKgamKqU94OGVGey8Cdg4VeXwWad0Z9Jfh1QV7n+Hy
-3/0KUf1qVQbJlPYg1KGxL1F8proNItVuMzv5ZFpGB5HXmEWiwKeY2RL7dWAAEyuT
-tKRHWgnaQxlPPjAyCjBKBjSGqHeYrikOelXJDeJ7A5q9zpgdx+Xj+hlYUqhj3rew
-l/62mG0o8xkLDqXZfQi5/O0NbER8mpIqUA3T3RzBrl6bWHQ8pnNtDMdglBFxlzEG
-Uqy2VBWZkekczWss4j7hAnuUvw3jc9KTs7kQPla2kTpnxdecdntgs80bHbu18AV/
-DB3srRMTeJU301/G4QiqVqG/APRNZRZVsh6FMNIyL18hEI4FoZX0muEB8LnIZ+bx
-+Uw6Z5awI6Nx9KEMjN8dW79Ml4aycUVVC46XQhTGC4dfzLOlYHzPitorlrR2oO2E
-A1GVZjhGR80m5da8YyghdQ+HMsu5yMSnDeGOFzrqIN/R3JKry7ahwEpC0hwtnlK3
-og3xXKOxdcM+zZ4L8yX9imkYpdEPJYqjygETSEvfC2OgU3FQ
+	serverKeyPEM = `
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCpjqmTSW5igLI3
+R9gzuMUkuwO3ZGC5S8LpoorzUuUwBEhbv2yaIda3XPTCaB6KOn4mKs48m1ViIyHr
+WkPRPjsRJ0nCiFzgWOKj6rTrupBEy97LiGNoOTdxeIdRb3d2lqNOkVbBu37ncK61
+PMj5qV9F9Lg5sG4jPsDoAUhAcTbB+01HxdCRRa2lgLrnAUWoK3s66HGuKbLdiNSK
+fnK1sJAYjUtdxz9DazS4hC7AP8iNoIrEo9wBDSIE8PhPPuGuLeaeYHUwJJ6+MnMW
+R6ZXtFL/SG89SQuf1LDf4zlthZ7cqS8rtM3I7iTmDfdJSY+wBvHfU2JF1H+luemw
+nTOmwEqHAgMBAAECggEBAJjG1d7DfHW+9lW/I3y/EMuewqN9C3YKYK65abADUkTo
+pvYcTlO3B8wiMtv0iwgL2lyzly6e29lYRJjWtWKVSw2Ss/BXhDAVhukhczEv4gxL
+Eg2cb82aOG3Cp1LmN+MfqjgB1wUq1xbcvl7JTWE/jnvvHAvHAAY75f9mIF8IY8l2
+GV0DyA0OJTlnAtYQQVuxMJ8NrH+JseFaqmk991gH4q95hTfVgBHvqJ6r1L+58pGR
+IHS5BLpy5xUfFQOCnPJ3RZhME6zzkmXYRv3sS8+cFJOhlFviJaPLBlvlH9gpkFDC
+Is8i5bhxio9xQHOkEQJhhet2N9rc8rzCsA28sI+wAnECgYEA0kK5ClS+f+9VqALZ
+1cjbfwJL0PweddDRnCdR1NgnLIIZxVbv6xjpzpTxfhOahKOqDivyACxi3n71eWZC
+A6Pl3Rs57mFQjrFr4dBa/rz0n/QhajJln5Nm1yla5kRS3dTPGHK0xcXKeXD4Rb9S
+4h/a2thfqLmSdAkozQeR5gGzzNkCgYEAznEyMQXNstlAlqorfRYaZWJc+s+k4J4u
+oqYVKjJshrgJErrGu+Fcz7+KMhHxqfM7nuA2CcB5IVcFvUP8aQBf2sw0eSFQVuGq
+3+wP+rc4ApIEPy9I6Xi1GFTdwZHIt2exfthczBtDh4XNXoYiIa42jcy3WvLHS34X
+tpFp9SFttl8CgYB6og/qxqKVW7JJ29/RoOTknyI5MdNSRAj9WrGPwsKWYwtE3f/w
+zwcPRi/TqPtmgU6eFWOAVmMUAliKBepa1S0sWMThFEE3+KNDgZKRIQRMhsc2eU5s
+VDyXIbeytgbe+1AOolhtQX9mdU1Y4M4mtQ2gtrKUZifVJcJ2UwP1cui7gQKBgAgt
+a7ONa0x+VpShQP+/dGQ3tT8qInnTSj2fHo+BV9MuTw2y4FRo5OhFyg+ZrlzxCZeN
+ghZ4zVOIwu1wV/tAzIs6M4noy+nlHoOoMinYQBu59PkbwmOdKG9CTVZxk+XP8bP4
+lhRvsAkaP7xSy99Rq0+KoGi13TccU4wjznKrVFE5AoGAN4B31tzm78CYv1BVWVfY
+QFc+/Rs65KVmAaQ5Mya2z49jci25xJWBmC+R4IbHFXnfIWFup/m2qdxCcfcFpTBQ
+YDPtwEMOI6hwdSjjpVXknb4d7sRDs3HTbUARfR0TGV+KSEHKbcnAjI3yuCrnGgU3
+ZEbao7tve6HgmpWi07s4YSI=
+-----END PRIVATE KEY-----
+`
+	// Server Certificate:
+	//    Data:
+	//        Version: 3 (0x2)
+	//        Signature Algorithm: sha256WithRSAEncryption
+	//        Issuer: CN=TEST-ONLY-CA
+	//        Validity
+	//            Not Before: May  3 02:16:01 2021 GMT
+	//            Not After : May  1 02:16:01 2031 GMT
+	//        Subject: CN=localhost
+	//        Subject Public Key Info:
+	//            Public Key Algorithm: rsaEncryption
+	//                RSA Public-Key: (2048 bit)
+	//            X509v3 Subject Alternative Name:
+	//                IP Address:127.0.0.1, DNS:localhost
+	serverCertPEM = `
+-----BEGIN CERTIFICATE-----
+MIIDdjCCAl6gAwIBAgIRAJAShFB0l1rYfsDgnx2awO0wDQYJKoZIhvcNAQELBQAw
+FzEVMBMGA1UEAwwMVEVTVC1PTkxZLUNBMB4XDTIxMDUwMzAyMTYwMVoXDTMxMDUw
+MTAyMTYwMVowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAqY6pk0luYoCyN0fYM7jFJLsDt2RguUvC6aKK81LlMARI
+W79smiHWt1z0wmgeijp+JirOPJtVYiMh61pD0T47ESdJwohc4Fjio+q067qQRMve
+y4hjaDk3cXiHUW93dpajTpFWwbt+53CutTzI+alfRfS4ObBuIz7A6AFIQHE2wftN
+R8XQkUWtpYC65wFFqCt7Ouhxrimy3YjUin5ytbCQGI1LXcc/Q2s0uIQuwD/IjaCK
+xKPcAQ0iBPD4Tz7hri3mnmB1MCSevjJzFkemV7RS/0hvPUkLn9Sw3+M5bYWe3Kkv
+K7TNyO4k5g33SUmPsAbx31NiRdR/pbnpsJ0zpsBKhwIDAQABo4G/MIG8MAkGA1Ud
+EwQCMAAwHQYDVR0OBBYEFOJfY8E/C8vB1kOA5WhlTKNY70QkMFIGA1UdIwRLMEmA
+FH7l5M/6ORudJjgvTxfBUZKbXsYyoRukGTAXMRUwEwYDVQQDDAxURVNULU9OTFkt
+Q0GCFE72qXaggK6UzUI5jPyGNKt2igEuMBMGA1UdJQQMMAoGCCsGAQUFBwMBMAsG
+A1UdDwQEAwIFoDAaBgNVHREEEzARhwR/AAABgglsb2NhbGhvc3QwDQYJKoZIhvcN
+AQELBQADggEBAEfiwGwORokJplu0O4xvA98zQWhehALJSsBxC0x3HYhDrMgc9ksG
+GUtHOKvKJTnA6SMtpDddfh+LN0YUh2Fwm6IxO1IVoEWa9v8cyF6fZqUrtTCFeD2/
+TCIdO4c3A1PqZwh4AxtwWvgKFi3BEXsYJ2lRA1lP/hsHvr+bjt3qTEaoDU7DJEO5
+k5h0xA9Q5XkW1dDlWaqQP+/5+f1ch9++AM9PrpOBE3uD7Z+ejZ6mgqhfp2F0MQIK
+XKjT3PNC/qxi5ZKBna5dTnRDyTa/6OoyzO5B8kILqf4SFO6s0/Xl7Trmm5ancs9B
+yEc731BHdlm3F3Q28U+2fvB0R8bdEYbkonk=
 -----END CERTIFICATE-----
 `
-	ca_s = `-----BEGIN CERTIFICATE-----
-MIIF/DCCA+SgAwIBAgIJAPu2wMXkvlz1MA0GCSqGSIb3DQEBCwUAMFsxCzAJBgNV
-BAYTAlhYMQ0wCwYDVQQIEwROb25lMQ0wCwYDVQQHEwROb25lMQ0wCwYDVQQKEwRO
-b25lMQ0wCwYDVQQLEwROb25lMRAwDgYDVQQDEwdkdW1teWNhMCAXDTE1MDcxNjE3
-NDMyN1oYDzIxMTUwNjIyMTc0MzI3WjBbMQswCQYDVQQGEwJYWDENMAsGA1UECBME
-Tm9uZTENMAsGA1UEBxMETm9uZTENMAsGA1UEChMETm9uZTENMAsGA1UECxMETm9u
-ZTEQMA4GA1UEAxMHZHVtbXljYTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC
-ggIBAOBYd9DycwftWY+ixY3ppC8jKlJkgH+gTRzMfnDABSH0Kx83sdzhfZ2/jPCy
-si7v+m62Zr64ovxIQhzebZX4L3ioQOMwm2Ri+9Y+OIShaIgtsZtJNFOAG1kjTVNV
-Wvh8rVMk1LgfOfSWyaHBW9TzJSkHuv9zdAqbo2MngfrFzNaUZDryeYH3+xqOXMIB
-JusMfR5PdBtXmOCh9H7++IvFLmakA48QCV/VvRntdufPX2dN2N1+oP+136ch5Izx
-JS41oQJ90MWYEgBXZJne14KW1+V15IRjGYubFJfDAiVTe3h0rgNySfbTI09/3Es5
-THZeZ3nfv6ZfGFqoaL4Dy1sj/HT9FMVvt8Af5Gsh4dfpoGZLNugr5xBGJbqe2QtU
-JK4zyiG0msVVrUWDhpNcYhookFk1vYJ1Ajj3drlTc2lJlZbxwYu507A3p+pJ0d0D
-8NrFyuOR9Jb347UCd87c6aYARqlIpqQb2yIvvtKLuEpM42iSApN23oes7PcMxtXv
-yCJVvqHzctRYHxhjc/Vls5PMLqFVBxqRuCDAemVLlAVM55//uNERZj5kovbhuJ+S
-1WdUekhY/8g9Q9FMr+qbjsjvFvix/Q3OvaEKUG3KzqMqRsVGPq7Ln/thQgDlRJWp
-neJU4YogODXYnM0j38Vu2J4hCECGqcUVLEQdoY5mVIcF1e+vAgMBAAGjgcAwgb0w
-HQYDVR0OBBYEFCbiSUklvWs3wnB7ivh9gz6EJRV/MIGNBgNVHSMEgYUwgYKAFCbi
-SUklvWs3wnB7ivh9gz6EJRV/oV+kXTBbMQswCQYDVQQGEwJYWDENMAsGA1UECBME
-Tm9uZTENMAsGA1UEBxMETm9uZTENMAsGA1UEChMETm9uZTENMAsGA1UECxMETm9u
-ZTEQMA4GA1UEAxMHZHVtbXljYYIJAPu2wMXkvlz1MAwGA1UdEwQFMAMBAf8wDQYJ
-KoZIhvcNAQELBQADggIBAMMTqea8PA80u53E8pzIW9h3PpogItIVs9qDFKEluxL+
-ONXWauQkcC4fivnipDSbUPzHAgnIwJ4A8w3kHc/pKDxpNJsm5QMJvZJxlZbNv92d
-ORw0gb8mmhdGVsc/MykvOCg2qD4kPu4y5ZZLC/8GXeQ9Ha3mDnVMZneRHfKgUzC4
-HwJ4/bkneb/tSHM5oD6EqCIhmiypmar+9Z4znFUisgqzI1MBJ0IndxIncJORcIsW
-FtvovOTrkGyDUt4Yo8YA9ekifqZVUEXmvKn20OJIAHP2kGbJen3b3bDCEBq2aIqy
-E5RREeWiIlVateAQ3m2XBI0phbAfJiZCAHmfVW/X3qANZi3bUdsR1CZdCyVL7JYF
-dd1jhpLs7wFNYR60XqelXv3xIcQON/WsI+aGqMtpFJSyWn+qY3LX1hJnHblC7OTr
-je8KOTmjIlVqn0TrlLrE3loR5k6wCjh8eqa2hwU5wK2HjUHXKrKjiHgcD0+KwPJq
-zCGgn6j7XLArHMmNZn3dtPeGqWyLlIOMYdbCMIMe8d6XkN2Bpu97D6B1vf/wOzg8
-U1rWbZCJitNK/qWI4M4MKX4k6fOUg/Vx7pejuU16SCxTEDEXXbV54vhWK2Xl0+BY
-GSDhNiPbMnysmreLxrnygHJCpCn2i75NwnUtDdb1nqGn3MsVVout+pdNyuN2RGUo
+
+	clientKeyPEM = `
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC2r9c65XVP+oAq
+P5xdu2DqKRgeMu5BiBqx4EpvuWRdJrV+MxTu64xfudovSECzHNeZUKnrj7H+JKFR
+a5g5YaORbEoD33vmWAVG+i49n/JxK481GVun6KHraf3MWxMxCJBmZyLEh8M6CrvG
+TY4vK4Mlc4ZRkeEQmz227lEbUUeEUvrfHPyYjIDVMR6QoFtAvLXehDEP6p6XzS6u
+mD5pS9gtCKTEq8FTelpiEGloaf4nXKpZwh1yUt8xrPwUamhFojBkKa+P7UrP0IWb
+HQGpRBxFwebGA04uquWofvBW4NeG+Pj/XZjdRlYDkVNDExcmAe0DplNBUq4+uHfo
+gdKAXcYHAgMBAAECggEAGTO+3GglO+hR4AIwfxnHb+ZFZn0eMzokfJ91hV4tA1DA
+vu0rGR6zmc0Y1WcBTfRPpd3j4xRKuMWy33mZYWkf2IL43vnorMk9ySHgWS4Ekyow
+MmISK+LC26gelB+IUT5eNVJLEJOuEgbDCsNONyGokPUT9ZLLWrAf3mmYFM2ssQtJ
+t9RbRkWhsL/0XKWnu0lz/Xq6SjfmDVJy2FU22RqHAzOnOkZR/5vMWtJru/rJGvfv
+bCzdfmDhF2+LXf2mtg8h/Ggatfu4HMu5wN7AkfxcNwJ00ltNXyxEWhAwrE5yn06s
+bg8tE7wHB7yFXHhmJw0nrKajUywlxrEDJLVEZFfRqQKBgQDmq7y/hUOzZFWi8sz+
+vDGVjV9IrMrOSeCHG+Vo0zpCmMIZnbokhiOOmlzpCvFQaNV6ckHOdFYvuv+yIqne
+TyvJAOeDqgCLPrB2ZZAFW9EMFRB39+7qWkQ1ozu0HGSt1+LuxPBCPlvGxSnEAbPs
+9l7OKlWUBnDkY0wdzZnvCQd0pQKBgQDKv0CM9rd9GV9mwmFhh/4iwQbJYiC9jaX5
+d68XcF7E2Gl5AQOOiHtLsRVfSAWaL2uuhyK1AXzT7Mp81yKTUKbSbuTBZrg4blSD
+LCK7x28056YGx4HHvdDMjZ1Qbn9AUJ4L6ApQu9LH/p9d2FtEl3YUEPJJjm1xF728
+Od8NIRUUOwKBgEw+a67qP4xmF6A6nON+FO2XwuzkoEw7QwmlgNh7KQCmOVH6PnKg
+G9Sg1SD6SvUHEbjdVz8EWRCBwM6Cgp9Gj/RqZhuw72kXGYCo5UfAJ4LU25Kr0r6H
+g5AvGibYU7baatn9ImTi87bpqHpvDae/b2q5t3ur/VigMaKQONc3ps05AoGBALL7
+WUHX/y25u2WczZjrE+ecXaBkNyD/LflntbNMaOz/W0UOJxSp2aZ9Yq+lhgSSPk5p
+T7NY59iyXiMNTKGd/lcgvGMbih+PDp5p1RPOQJcEtKWhdClfoTcjATBjC4U8Zfl+
+07RnyvDxD8Ep4ZBQ4VVfjHRw/p5q5f2HXSha/x/HAoGBALSdtyHNPJLsUqou14oQ
+lbnRgbuRDOyHxDmgHr5oAVEaTt088jyPQJRAZOZFLAZH5G1pJ5Xkca3FB/TmJwDa
+sRzzNIcYhZ5dUZZBap6FOqhzNAkQhYBAHEH7qNg2A4KDCleZLTti+IB+3wDwF+U3
+iNVFLPM8+L5NVhYZnzr3OsYa
+-----END PRIVATE KEY-----
+`
+
+	// Client Certificate:
+	//    Data:
+	//        Version: 3 (0x2)
+	//        Signature Algorithm: sha256WithRSAEncryption
+	//        Issuer: CN=TEST-ONLY-CA
+	//        Validity
+	//            Not Before: May  3 04:01:52 2021 GMT
+	//            Not After : May  1 04:01:52 2031 GMT
+	//        Subject: CN=client
+	//        Subject Public Key Info:
+	//            Public Key Algorithm: rsaEncryption
+	//                RSA Public-Key: (2048 bit)
+	//        X509v3 extensions:
+	//            X509v3 Basic Constraints:
+	//                CA:FALSE
+	//            X509v3 Extended Key Usage:
+	//                TLS Web Client Authentication
+	//    Signature Algorithm: sha256WithRSAEncryption
+	clientCertPEM = `
+-----BEGIN CERTIFICATE-----
+MIIDVzCCAj+gAwIBAgIRALFKZyAB8AQy/jVcH5n0gxAwDQYJKoZIhvcNAQELBQAw
+FzEVMBMGA1UEAwwMVEVTVC1PTkxZLUNBMB4XDTIxMDUwMzA0MDE1MloXDTMxMDUw
+MTA0MDE1MlowETEPMA0GA1UEAwwGY2xpZW50MIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEAtq/XOuV1T/qAKj+cXbtg6ikYHjLuQYgaseBKb7lkXSa1fjMU
+7uuMX7naL0hAsxzXmVCp64+x/iShUWuYOWGjkWxKA9975lgFRvouPZ/ycSuPNRlb
+p+ih62n9zFsTMQiQZmcixIfDOgq7xk2OLyuDJXOGUZHhEJs9tu5RG1FHhFL63xz8
+mIyA1TEekKBbQLy13oQxD+qel80urpg+aUvYLQikxKvBU3paYhBpaGn+J1yqWcId
+clLfMaz8FGpoRaIwZCmvj+1Kz9CFmx0BqUQcRcHmxgNOLqrlqH7wVuDXhvj4/12Y
+3UZWA5FTQxMXJgHtA6ZTQVKuPrh36IHSgF3GBwIDAQABo4GjMIGgMAkGA1UdEwQC
+MAAwHQYDVR0OBBYEFB0IGxBzTklkqBF5dZkVoMQwfVvIMFIGA1UdIwRLMEmAFH7l
+5M/6ORudJjgvTxfBUZKbXsYyoRukGTAXMRUwEwYDVQQDDAxURVNULU9OTFktQ0GC
+FE72qXaggK6UzUI5jPyGNKt2igEuMBMGA1UdJQQMMAoGCCsGAQUFBwMCMAsGA1Ud
+DwQEAwIHgDANBgkqhkiG9w0BAQsFAAOCAQEANdQWQqi3Ai4YuRkEqHULGjuhRRiF
+GIhIOAk478a6+DYvgzwINfP0BkMG657PaLsPC9iBgJMJ66A5t2ILFDD2SZh41jx2
+7Hn4svWX1KruUrjNkrD39HMOhEHrv7zbxQRJguQubNepVgdcob1sMwkXVF1+BMl4
+SZHinCdoM918NOBAjwLyoAjrFLEDsJ2Hj+bWomzD5ab4LQtdcLVa9id2MAdRTuWv
+7iLGmCaM60O7IdZh7DxmR7tU/+sJfuAuQhP1fQ9DNi9J5VY5EAfJ9e4rWfUEXYRC
+eInlt0lzAVo2mdju1e22aZmNYCSgQRC3FDEBlSQ5ZLU6X1R5aCpMae9nfQ==
+-----END CERTIFICATE-----
+`
+
+	// CA Certificate:
+	//    Data:
+	//        Version: 3 (0x2)
+	//        Signature Algorithm: sha256WithRSAEncryption
+	//        Issuer: CN = TEST-ONLY-CA
+	//        Validity
+	//            Not Before: May  3 02:16:01 2021 GMT
+	//            Not After : Apr 29 02:16:01 2036 GMT
+	//        Subject: CN = TEST-ONLY-CA
+	//        Subject Public Key Info:
+	//            Public Key Algorithm: rsaEncryption
+	//                RSA Public-Key: (2048 bit)
+	//        X509v3 extensions:
+	//            X509v3 Basic Constraints:
+	//                CA:TRUE
+	//            X509v3 Key Usage:
+	//                Certificate Sign, CRL Sign
+	caCertPEM = `-----BEGIN CERTIFICATE-----
+MIIDTjCCAjagAwIBAgIUTvapdqCArpTNQjmM/IY0q3aKAS4wDQYJKoZIhvcNAQEL
+BQAwFzEVMBMGA1UEAwwMVEVTVC1PTkxZLUNBMB4XDTIxMDUwMzAyMTYwMVoXDTM2
+MDQyOTAyMTYwMVowFzEVMBMGA1UEAwwMVEVTVC1PTkxZLUNBMIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvxGdCX01h6JdaHebxKopSkMQQhsrESTMtDwT
+fwGskkyFnzlMr57OILGHeuNcxlaRKSlL5tZY4BAmDibl+5DXttYn1BRLIqTqfizi
+wtl5jpcR2+A6t27qfsszApNaIsqZ8mKgVxDiS6yiql7XKSQ/mjYpOc+Co26XilZx
+k69ai3SlHR6aIUKtpRCPiE3Po5x5x/x+NSkfP1CqQ6ldvqx11AtIWR1pItIOBxrz
+BWdTigXbr9WMnc7cY6ZI1chUr+HqocisBs68dHdkkZgEc63GdHyF8UIP+7UlmKNq
+Qg0+deaiq4kjz6fFoR5qt6LaQu9tH4U16uohQSgKXoGOM9a/eQIDAQABo4GRMIGO
+MB0GA1UdDgQWBBR+5eTP+jkbnSY4L08XwVGSm17GMjBSBgNVHSMESzBJgBR+5eTP
++jkbnSY4L08XwVGSm17GMqEbpBkwFzEVMBMGA1UEAwwMVEVTVC1PTkxZLUNBghRO
+9ql2oICulM1COYz8hjSrdooBLjAMBgNVHRMEBTADAQH/MAsGA1UdDwQEAwIBBjAN
+BgkqhkiG9w0BAQsFAAOCAQEAJPe7PvPj+ET7sCVgCr6c2nyQmlco38Le7j4Q71kR
+mtK9iozTiX3XLBlJvLurQx6lhDj+2IFc+JYFMdD7d3tSVBPq4KHCP4jXkR//sjeq
+hg0oKIsxpi6wjF8UDXBnWNagqEvn/FW4OR5U0QEz4ei/PgK3MYbb1A9KYPT6389r
+IcZRKBhPmI6rFPmxz9eigXH9YqdMrUI0RSvYPSo8smajjHb78e8Z2p0TKB9R7M2v
+w3awX8nFu2WLBD7RvLkDYlCH425pjbPlFOHqHXymLyaJkmJfgF4xP5obNKzDFU55
+IqZWYDgZFUyDuRjZPAe39JPOP05gXRdVKH28m1IryPwgOA==
 -----END CERTIFICATE-----
 `
 )


### PR DESCRIPTION
##  Unit test fixes
The unit tests, at least under go 1.16, were failing:
> panic: x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0

I put in new certificates, separating the client from the server certificate.  The server certificate now has a subject alternative name section which includes both `localhost` and `127.0.0.1`.

##  Timestamp parsing fixes
RFC 3339 timestamps do not have a fixed size length, but they also do not contain any spaces:
https://tools.ietf.org/html/rfc3339#section-5.8

I changed the code to terminate after the first space instead using the size of the formatting string to fix the issue.

##  Go modules support
Added go modules support.

___
If you are not happy with something or want something done better, let me know and I'll try to fix it.