### PR TITLE
Allow setting timeout during TLS Handshake

### DIFF
--- a/server.go
+++ b/server.go
@@ -38,6 +38,7 @@ type Server struct {
 	handler                 Handler
 	lastError               error
 	readTimeoutMilliseconds int64
+	tlsHandshakeTimeout     time.Duration
 	tlsPeerNameFunc         TlsPeerNameFunc
 	datagramPool            sync.Pool
 }
@@ -64,6 +65,10 @@ func (s *Server) SetHandler(handler Handler) {
 //Sets the connection timeout for TCP connections, in milliseconds
 func (s *Server) SetTimeout(millseconds int64) {
 	s.readTimeoutMilliseconds = millseconds
+}
+
+func (s *Server) SetTlsHandshakeTimeout(d time.Duration) {
+	s.tlsHandshakeTimeout = d
 }
 
 // Set the function that extracts a TLS peer name from the TLS connection
@@ -206,6 +211,9 @@ func (s *Server) goScanConnection(connection net.Conn) {
 	tlsPeer := ""
 	if tlsConn, ok := connection.(*tls.Conn); ok {
 		// Handshake now so we get the TLS peer information
+		if s.tlsHandshakeTimeout > 0 {
+			tlsConn.SetDeadline(time.Now().Add(s.tlsHandshakeTimeout))
+		}
 		if err := tlsConn.Handshake(); err != nil {
 			connection.Close()
 			return


### PR DESCRIPTION
Buggy clients might never respond during the TLS handshake phase. This
change adds a config setting to set a read timeout before calling
handshake. I think the handshake involves multiple reads but this
setting should help with clients who never respond.