### PR TITLE
do not block accepting connections

### DIFF
--- a/server.go
+++ b/server.go
@@ -184,7 +184,7 @@ func (s *Server) goAcceptConnection(listener net.Listener) {
 				continue
 			}
 
-			s.goScanConnection(connection)
+			go s.goScanConnection(connection)
 		}
 
 		s.wait.Done()


### PR DESCRIPTION
When using a plain TCP listener, goScanConnection creates some data
structures and moves on to scan which is wrapped in a goroutine.

When using a TLS listener, goScanConnection does not return until the
TLS handshake is complete. A lot can go wrong during this stage.

This change wraps goScanConnection in a goroutine to avoid blocking
accepting the next connection.