### PR TITLE
Fix panic when parsing line with only priority.

### DIFF
--- a/internal/syslogparser/rfc3164/rfc3164.go
+++ b/internal/syslogparser/rfc3164/rfc3164.go
@@ -105,7 +105,9 @@ func (p *Parser) parsePriority() (syslogparser.Priority, error) {
 
 func (p *Parser) parseHeader() (header, error) {
 	hdr := header{}
-	var err error
+	if p.cursor >= p.l {
+		return hdr, syslogparser.ErrEOL
+	}
 
 	ts, err := p.parseTimestamp()
 	if err != nil {

--- a/internal/syslogparser/rfc3164/rfc3164_test.go
+++ b/internal/syslogparser/rfc3164/rfc3164_test.go
@@ -310,6 +310,23 @@ func (s *Rfc3164TestSuite) TestParseContent_Valid(c *C) {
 	c.Assert(p.cursor, Equals, len(content))
 }
 
+func (s *Rfc3164TestSuite) TestParser_PriorityOnly(c *C) {
+	buff := []byte("<34>")
+
+	p := NewParser(buff)
+	expectedP := &Parser{
+		buff:     buff,
+		cursor:   0,
+		l:        len(buff),
+		location: time.UTC,
+	}
+
+	c.Assert(p, DeepEquals, expectedP)
+
+	err := p.Parse()
+	c.Assert(err, Equals, syslogparser.ErrEOL)
+}
+
 func (s *Rfc3164TestSuite) BenchmarkParseTimestamp(c *C) {
 	buff := []byte("Oct 11 22:14:15")
 


### PR DESCRIPTION
parseHeader was not checking that the end of the input hasn't been reached, and parseTimestamp and parseHostname assume that there's at least one character available. Avoid a panic by checking in parseHeader, and add a test to verify.